### PR TITLE
Fix minor static analysis issues

### DIFF
--- a/LicenseHeaderManager/ButtonHandler/SolutionLevelButtonThreadWorker.cs
+++ b/LicenseHeaderManager/ButtonHandler/SolutionLevelButtonThreadWorker.cs
@@ -45,8 +45,7 @@ namespace LicenseHeaderManager.ButtonHandler
         OutputWindowHandler.WriteMessage (exception.ToString());
       }
 
-      if (ThreadDone != null)
-          ThreadDone(this, EventArgs.Empty);
+      ThreadDone?.Invoke(this, EventArgs.Empty);
     }
   }
 }

--- a/LicenseHeaderManager/Headers/LicenseHeaderFinder.cs
+++ b/LicenseHeaderManager/Headers/LicenseHeaderFinder.cs
@@ -126,7 +126,7 @@ namespace LicenseHeaderManager.Headers
             header.Add (line);
         }
 
-        if (wholeFile.EndsWith(NewLineConst.CR) || wholeFile.EndsWith(NewLineConst.CRLF) || wholeFile.EndsWith(NewLineConst.LF))
+        if (wholeFile.EndsWith(NewLineConst.CR) || wholeFile.EndsWith(NewLineConst.LF))
         {
           header.Add(string.Empty);
         }

--- a/LicenseHeaderManager/Options/LinkedCommand.cs
+++ b/LicenseHeaderManager/Options/LinkedCommand.cs
@@ -60,8 +60,7 @@ namespace LicenseHeaderManager.Options
 
     private void OnPropertyChanged (string propertyName)
     {
-      if (PropertyChanged != null)
-        PropertyChanged (this, new PropertyChangedEventArgs (propertyName));
+      PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
   }
 }

--- a/LicenseHeaderManager/Options/OptionsPage.cs
+++ b/LicenseHeaderManager/Options/OptionsPage.cs
@@ -47,23 +47,20 @@ namespace LicenseHeaderManager.Options
         if (_linkedCommands != null)
         {
           _linkedCommands.CollectionChanged -= OnLinkedCommandsChanged;
-          if (LinkedCommandsChanged != null)
-            LinkedCommandsChanged (_linkedCommands, new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Remove, _linkedCommands));
+          LinkedCommandsChanged?.Invoke(_linkedCommands, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, _linkedCommands));
         }
         _linkedCommands = value;
         if (_linkedCommands != null)
         {
           _linkedCommands.CollectionChanged += OnLinkedCommandsChanged;
-          if (LinkedCommandsChanged != null)
-            LinkedCommandsChanged (value, new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Add, _linkedCommands));
+          LinkedCommandsChanged?.Invoke(value, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, _linkedCommands));
         }
       }
     }
 
     private void OnLinkedCommandsChanged (object sender, NotifyCollectionChangedEventArgs e)
     {
-      if (LinkedCommandsChanged != null)
-        LinkedCommandsChanged (sender, e);
+      LinkedCommandsChanged?.Invoke(sender, e);
     }
 
     public OptionsPage ()

--- a/LicenseHeaderManager/SolutionUpdateViewModels/SolutionUpdateViewModel.cs
+++ b/LicenseHeaderManager/SolutionUpdateViewModels/SolutionUpdateViewModel.cs
@@ -44,10 +44,7 @@ namespace LicenseHeaderManager.SolutionUpdateViewModels
     public event PropertyChangedEventHandler PropertyChanged;
     private void NotifyPropertyChanged(String propertyName = "")
     {
-        if (PropertyChanged != null)
-        {
-            PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-        }
+      PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
   }
 }


### PR DESCRIPTION
[V3053](https://www.viva64.com/en/w/V3053) An excessive expression. Examine the substrings "\r\n" and "\n". LicenseHeaderFinder.cs 129
[V3083](https://www.viva64.com/en/w/V3083) Unsafe invocation of event 'ThreadDone', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. SolutionLevelButtonThreadWorker.cs 49
[V3083](https://www.viva64.com/en/w/V3083) Unsafe invocation of event 'LinkedCommandsChanged', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. OptionsPage.cs 51, 58, 66
[V3083](https://www.viva64.com/en/w/V3083) Unsafe invocation of event 'PropertyChanged', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. LinkedCommand.cs 64
[V3083](https://www.viva64.com/en/w/V3083) Unsafe invocation of event 'PropertyChanged', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. SolutionUpdateViewModel.cs 49

Analysed using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) as a part of [pinguem.ru](https://pinguem.ru) competition