### PR TITLE
Settings storage fix

### DIFF
--- a/LicenseHeaderManager/Options/LanguagesPage.cs
+++ b/LicenseHeaderManager/Options/LanguagesPage.cs
@@ -29,11 +29,20 @@ namespace LicenseHeaderManager.Options
   [Guid ("D1B5984C-1693-4F26-891E-0BA3BF5760B4")]
   public class LanguagesPage : VersionedDialogPage, ILanguagesPage
   {
+    private readonly LanguageConverter _languageConverter = new LanguageConverter();
+
     //serialized properties
 
-    [TypeConverter (typeof(LanguageConverter))]
-    [DesignerSerializationVisibility (DesignerSerializationVisibility.Visible)]
+    [DesignerSerializationVisibility (DesignerSerializationVisibility.Hidden)]
     public IList<Language> Languages { get; set; }
+
+    [DesignerSerializationVisibility (DesignerSerializationVisibility.Visible)]
+    // ReSharper disable once UnusedMember.Global
+    public string LanguagesSerialized
+    {
+      get { return _languageConverter.ToXml (Languages); }
+      set { Languages = new ObservableCollection<Language> (_languageConverter.FromXml (value)); }
+    }
 
     public LanguagesPage ()
     {

--- a/LicenseHeaderManager/Options/LanguagesPage.cs
+++ b/LicenseHeaderManager/Options/LanguagesPage.cs
@@ -29,6 +29,22 @@ namespace LicenseHeaderManager.Options
   [Guid ("D1B5984C-1693-4F26-891E-0BA3BF5760B4")]
   public class LanguagesPage : VersionedDialogPage, ILanguagesPage
   {
+    private readonly IList<Language> _defaultLanguages = new ObservableCollection<Language>
+    {
+      new Language { Extensions = new[] { ".cs" }, LineComment = "//", BeginComment = "/*", EndComment = "*/", BeginRegion = "#region", EndRegion = "#endregion" },
+      new Language { Extensions = new[] { ".c", ".cpp", ".cxx", ".h", ".hpp" }, LineComment = "//", BeginComment = "/*", EndComment = "*/" },
+      new Language { Extensions = new[] { ".vb" }, LineComment = "'", BeginRegion = "#Region", EndRegion = "#End Region" },
+      new Language { Extensions = new[] { ".aspx", ".ascx", }, BeginComment = "<%--", EndComment = "--%>" },
+      new Language { Extensions = new[] { ".htm", ".html", ".xhtml", ".xml", ".xaml", ".resx", ".config", ".xsd" }, BeginComment = "<!--", EndComment = "-->", SkipExpression = @"(<\?xml(.|\s)*?\?>)?(\s*<!DOCTYPE(.|\s)*?>)?( |\t)*(\n|\r\n|\r)?" },
+      new Language { Extensions = new[] { ".css" }, BeginComment = "/*", EndComment = "*/" },
+      new Language { Extensions = new[] { ".js", ".ts" }, LineComment = "//", BeginComment = "/*", EndComment = "*/", SkipExpression = @"(/// *<reference.*/>( |\t)*(\n|\r\n|\r)?)*" },
+      new Language { Extensions = new[] { ".sql" }, BeginComment = "/*", EndComment = "*/", LineComment = "--" },
+      new Language { Extensions = new[] { ".php" }, BeginComment = "/*", EndComment = "*/", LineComment = "//" },
+      new Language { Extensions = new[] { ".wxs", ".wxl", ".wxi" }, BeginComment = "<!--", EndComment = "-->" },
+      new Language { Extensions = new[] { ".py" }, BeginComment = "\"\"\"", EndComment = "\"\"\"" },
+      new Language { Extensions = new[] { ".fs" }, BeginComment = "(*", EndComment = "*)", LineComment = "//" },
+    };
+
     private readonly LanguageConverter _languageConverter = new LanguageConverter();
 
     //serialized properties
@@ -51,21 +67,7 @@ namespace LicenseHeaderManager.Options
 
     public override sealed void ResetSettings ()
     {
-      Languages = new ObservableCollection<Language>
-      {
-        new Language { Extensions = new[] { ".cs" }, LineComment = "//", BeginComment = "/*", EndComment = "*/", BeginRegion = "#region", EndRegion = "#endregion"},
-        new Language { Extensions = new[] { ".c", ".cpp", ".cxx", ".h", ".hpp" }, LineComment = "//", BeginComment = "/*", EndComment = "*/"},
-        new Language { Extensions = new[] { ".vb" }, LineComment = "'", BeginRegion = "#Region", EndRegion = "#End Region" },
-        new Language { Extensions = new[] { ".aspx", ".ascx", }, BeginComment = "<%--", EndComment = "--%>" },
-        new Language { Extensions = new[] { ".htm", ".html", ".xhtml", ".xml", ".xaml", ".resx", ".config", ".xsd" }, BeginComment = "<!--", EndComment = "-->", SkipExpression = @"(<\?xml(.|\s)*?\?>)?(\s*<!DOCTYPE(.|\s)*?>)?( |\t)*(\n|\r\n|\r)?" },
-        new Language { Extensions = new[] { ".css" }, BeginComment = "/*", EndComment = "*/" },
-        new Language { Extensions = new[] { ".js", ".ts" }, LineComment = "//", BeginComment = "/*", EndComment = "*/", SkipExpression = @"(/// *<reference.*/>( |\t)*(\n|\r\n|\r)?)*"},
-        new Language { Extensions = new[] { ".sql" }, BeginComment = "/*", EndComment = "*/", LineComment = "--"},
-        new Language { Extensions = new[] { ".php" }, BeginComment = "/*", EndComment = "*/", LineComment = "//"},
-        new Language { Extensions = new[] { ".wxs", ".wxl", ".wxi" }, BeginComment = "<!--", EndComment = "-->"},
-        new Language { Extensions = new[] { ".py" }, BeginComment = "\"\"\"", EndComment = "\"\"\""},
-        new Language { Extensions = new[] { ".fs" }, BeginComment = "(*", EndComment = "*)", LineComment = "//"},
-      };
+      Languages = _defaultLanguages;
       base.ResetSettings ();
     }
 
@@ -81,6 +83,7 @@ namespace LicenseHeaderManager.Options
     }
 
     #region version updates
+
     protected override IEnumerable<UpdateStep> GetVersionUpdateSteps ()
     {
       yield return new UpdateStep (new Version (1, 1, 4), AddDefaultSkipExpressions_1_1_4);
@@ -89,6 +92,7 @@ namespace LicenseHeaderManager.Options
       yield return new UpdateStep (new Version (1, 3, 2), AddXmlXsd_1_3_2);
       yield return new UpdateStep (new Version (1, 3, 6), ReduceToBaseExtensions_1_3_6);
       yield return new UpdateStep (new Version (1, 7, 3), AddMultipleDefaultExtensions_1_7_3);
+      yield return new UpdateStep (new Version (3, 0, 1), MigrateStorageLocation_3_0_1);
     }
 
     private void AddDefaultSkipExpressions_1_1_4 ()
@@ -226,6 +230,21 @@ namespace LicenseHeaderManager.Options
       }
     }
 
+    private void MigrateStorageLocation_3_0_1 ()
+    {
+      if (!System.Version.TryParse (Version, out var version) || version < new Version (3, 0, 0))
+      {
+        LoadRegistryValuesBefore_3_0_0();
+      }
+      else
+      {
+        var migratedLanguagesPage = new LanguagesPage();
+        LoadRegistryValuesBefore_3_0_0 (migratedLanguagesPage);
+
+        Languages = migratedLanguagesPage.Languages;
+      }
+    }
+
     private bool AddExtensionToExistingExtension (string existingExtension, string newExtension)
     {
       if (Languages.Any (x => x.Extensions.Contains (newExtension)))
@@ -269,6 +288,7 @@ namespace LicenseHeaderManager.Options
 
       return false;
     }
+
     #endregion
   }
 }

--- a/LicenseHeaderManager/Options/OptionsPage.cs
+++ b/LicenseHeaderManager/Options/OptionsPage.cs
@@ -12,6 +12,8 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
 #endregion
 
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -27,6 +29,12 @@ namespace LicenseHeaderManager.Options
   [Guid ("EB6F9B18-D203-43E3-8033-35AD9BEFC70D")]
   public class OptionsPage : VersionedDialogPage, IOptionsPage
   {
+
+    private const bool c_defaultInsertInNewFiles = false;
+    private const bool c_defaultUseRequiredKeywords = true;
+    private const string c_defaultRequiredKeywords = "license, copyright, (c), ©";
+    private readonly ObservableCollection<LinkedCommand> _defaultLinkedCommands = new ObservableCollection<LinkedCommand>();
+
     private readonly LinkedCommandConverter _linkedCommandConverter = new LinkedCommandConverter();
 
     public event NotifyCollectionChangedEventHandler LinkedCommandsChanged;
@@ -36,6 +44,7 @@ namespace LicenseHeaderManager.Options
       get { return GetService (typeof(DTE)) as DTE2; }
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Commands Commands
     {
       get { return Dte.Commands; }
@@ -90,10 +99,10 @@ namespace LicenseHeaderManager.Options
 
     public override sealed void ResetSettings ()
     {
-      InsertInNewFiles = false;
-      UseRequiredKeywords = true;
-      RequiredKeywords = "license, copyright, (c), ©";
-      LinkedCommands = new ObservableCollection<LinkedCommand>();
+      InsertInNewFiles = c_defaultInsertInNewFiles;
+      UseRequiredKeywords = c_defaultUseRequiredKeywords;
+      RequiredKeywords = c_defaultRequiredKeywords;
+      LinkedCommands = _defaultLinkedCommands;
       base.ResetSettings();
     }
 
@@ -107,5 +116,41 @@ namespace LicenseHeaderManager.Options
         return host;
       }
     }
+
+    #region version updates
+
+    protected override IEnumerable<UpdateStep> GetVersionUpdateSteps ()
+    {
+      yield return new UpdateStep (new Version (3, 0, 1), MigrateStorageLocation_3_0_1);
+    }
+
+    private void MigrateStorageLocation_3_0_1 ()
+    {
+      if (!System.Version.TryParse (Version, out var version) || version < new Version (3, 0, 0))
+      {
+        LoadRegistryValuesBefore_3_0_0();
+      }
+      else
+      {
+        var migratedOptionsPage = new OptionsPage();
+        LoadRegistryValuesBefore_3_0_0 (migratedOptionsPage);
+
+        InsertInNewFiles = ThreeWaySelectionForMigration (
+            InsertInNewFiles,
+            migratedOptionsPage.InsertInNewFiles,
+            c_defaultInsertInNewFiles);
+        UseRequiredKeywords = ThreeWaySelectionForMigration (
+            UseRequiredKeywords,
+            migratedOptionsPage.UseRequiredKeywords,
+            c_defaultUseRequiredKeywords);
+        RequiredKeywords = ThreeWaySelectionForMigration (
+            RequiredKeywords,
+            migratedOptionsPage.RequiredKeywords,
+            c_defaultRequiredKeywords);
+        LinkedCommands = migratedOptionsPage.LinkedCommands;
+      }
+    }
+
+    #endregion
   }
 }

--- a/LicenseHeaderManager/Options/OptionsPage.cs
+++ b/LicenseHeaderManager/Options/OptionsPage.cs
@@ -27,6 +27,8 @@ namespace LicenseHeaderManager.Options
   [Guid ("EB6F9B18-D203-43E3-8033-35AD9BEFC70D")]
   public class OptionsPage : VersionedDialogPage, IOptionsPage
   {
+    private readonly LinkedCommandConverter _linkedCommandConverter = new LinkedCommandConverter();
+
     public event NotifyCollectionChangedEventHandler LinkedCommandsChanged;
 
     private DTE2 Dte
@@ -46,8 +48,7 @@ namespace LicenseHeaderManager.Options
 
     private ObservableCollection<LinkedCommand> _linkedCommands;
 
-    [TypeConverter (typeof(LinkedCommandConverter))]
-    [DesignerSerializationVisibility (DesignerSerializationVisibility.Visible)]
+    [DesignerSerializationVisibility (DesignerSerializationVisibility.Hidden)]
     public ObservableCollection<LinkedCommand> LinkedCommands
     {
       get { return _linkedCommands; }
@@ -67,6 +68,14 @@ namespace LicenseHeaderManager.Options
           LinkedCommandsChanged?.Invoke (value, new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Add, _linkedCommands));
         }
       }
+    }
+
+    [DesignerSerializationVisibility (DesignerSerializationVisibility.Visible)]
+    // ReSharper disable once UnusedMember.Global
+    public string LinkedCommandsSerialized
+    {
+      get { return _linkedCommandConverter.ToXml (_linkedCommands); }
+      set { _linkedCommands = new ObservableCollection<LinkedCommand> (_linkedCommandConverter.FromXml (value)); }
     }
 
     private void OnLinkedCommandsChanged (object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
Fixing issue #108 

- Added collection serialization by adding string properties, converting while getting/setting.
- Added a migration to version 3.0.1, merging old and new settings values.
  - Settings stored in a collection (**Language** and **LinkedCommands**) are always restored, as version 3.0.0 could not store them at all.
  - For the remaining settings, the most recent changes are chosen.